### PR TITLE
2022 Rebuild - Bugfix - Sanitize pageKey of special characters

### DIFF
--- a/pages/create.tsx
+++ b/pages/create.tsx
@@ -64,9 +64,9 @@ export default function Create() {
       <ul>
         <li>No adult or hate content.</li>
         <li>Provide warnings for stuff like excessive profanity</li>
-        <li>No special characters in the title.</li>
+        <li>If you add special characters in the title, they will be removed from the post&apos;s URL.</li>
         <li>I would advise against using H1 (# header) tags inside the content since the title is already formatted as an H1.</li>
-        <li>If you don&apos;t like how your post looks - reach out to me.</li>
+        <li>If you don&apos;t like how your post looks or you want to delete it - reach out to me. My hope is to eventually implement draft functionality.</li>
       </ul>
       <form className={styles.blogForm} onSubmit={handleSubmit}>
         <label htmlFor="btitle">Title</label>

--- a/server/blog.service.tsx
+++ b/server/blog.service.tsx
@@ -41,7 +41,9 @@ export async function addBlogToUserData(authorID: string, title: string) {
 export async function createBlogOnFirestore(text: string, author: string, authorID: string, title: string, blogID: string): Promise<WriteResult> {
   const firestore = await getFirestoreInstance();
 
-  const pageKey = title.toLowerCase().replace(/ /g, '-');
+  // replace anything that is not an alpha-numeric character or a space with nothing
+  const sanitizedTitle = title.replace(/[^a-zA-Z0-9\s]/g, '');
+  const pageKey = sanitizedTitle.toLowerCase().replace(/ /g, '-');
   const docRef = firestore.doc(`blogs/${pageKey}`);
   const date = Date.now() + '';
 


### PR DESCRIPTION
Previously, the writers could enter special characters into the title and add the special characters to the URL and indexes of the database - causing some issues. This fixes it by only allowing alpha-numeric characters along with spaces.